### PR TITLE
Enable switch-view to list.

### DIFF
--- a/src/components/buttons/SwitchView.vue
+++ b/src/components/buttons/SwitchView.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { mapState, mapMutations } from 'vuex'
-import { users as api } from '@/api'
+// import { users as api } from '@/api'
 
 export default {
   name: 'switch-button',
@@ -29,7 +29,7 @@ export default {
       }
 
       try {
-        await api.update(data, ['viewMode'])
+        //await api.update(data, ['viewMode'])
         this.updateUser(data)
       } catch (e) {
         this.$showError(e)

--- a/src/components/buttons/SwitchView.vue
+++ b/src/components/buttons/SwitchView.vue
@@ -7,7 +7,6 @@
 
 <script>
 import { mapState, mapMutations } from 'vuex'
-// import { users as api } from '@/api'
 
 export default {
   name: 'switch-button',
@@ -28,12 +27,7 @@ export default {
         viewMode: (this.icon === 'view_list') ? 'list' : 'mosaic'
       }
 
-      try {
-        //await api.update(data, ['viewMode'])
-        this.updateUser(data)
-      } catch (e) {
-        this.$showError(e)
-      }
+      this.updateUser(data)
     }
   }
 }

--- a/src/components/files/Listing.vue
+++ b/src/components/files/Listing.vue
@@ -14,7 +14,8 @@
       <div class="item header">
         <div></div>
         <div>
-          <p :class="{ active: nameSorted }" class="name"
+<!-- Previous Item Header -->
+          <!-- <p :class="{ active: nameSorted }" class="name"
             role="button"
             tabindex="0"
             @click="sort('name')"
@@ -23,7 +24,6 @@
             <span>{{ $t('files.name') }}</span>
             <i class="material-icons">{{ nameIcon }}</i>
           </p>
-
           <p :class="{ active: sizeSorted }" class="size"
             role="button"
             tabindex="0"
@@ -41,7 +41,20 @@
             :aria-label="$t('files.sortByLastModified')">
             <span>{{ $t('files.lastModified') }}</span>
             <i class="material-icons">{{ modifiedIcon }}</i>
+          </p> -->
+
+<!-- New Item Header -->
+          <p class="name">
+            <span>{{ $t('files.name') }}</span>
           </p>
+          <p class="size">
+            <span>{{ $t('files.size') }}</span>
+          </p>
+          <p class="modified">
+            <span>{{ $t('files.lastModified') }}</span>
+          </p>
+
+
         </div>
       </div>
     </div>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 const name = 'KDrive';
 const disableExternal = false;
-const baseURL = 'http://localhost:8080';
+const baseURL = '';
 const signup = false;
 const version = '(untracked)';
 const logoURL = `/img/logo.svg`;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 const name = 'KDrive';
 const disableExternal = false;
-const baseURL = '';
+const baseURL = 'http://localhost:8080';
 const signup = false;
 const version = '(untracked)';
 const logoURL = `/img/logo.svg`;


### PR DESCRIPTION
Disable the update of the `viewMode` field of the user (because we don't hold user information for now).
Also disable the sort by field feature because it doe's the sorting seems to be calculated in the server side and saved in the user metadata.

Signed-off-by: Yonatan <yonatald@gmail.com>